### PR TITLE
feat(di): add bulk import functionality for DIs from .xlsx files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,8 @@
         "reflect-metadata": "^0.1.13",
         "rxjs": "^7.2.0",
         "socket.io-client": "^4.7.5",
-        "uuid": "^11.0.5"
+        "uuid": "^11.0.5",
+        "xlsx": "^0.18.5"
       },
       "devDependencies": {
         "@nestjs/cli": "^9.0.0",
@@ -3376,6 +3377,15 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/adler-32": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
+      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/agent-base": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
@@ -4444,6 +4454,19 @@
         }
       ]
     },
+    "node_modules/cfb": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
+      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "crc-32": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -4636,6 +4659,15 @@
         "node": ">= 0.12.0"
       }
     },
+    "node_modules/codepage": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
+      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/collect-v8-coverage": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.2.tgz",
@@ -4800,6 +4832,18 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/create-jest": {
@@ -6010,6 +6054,15 @@
       "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/frac": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
+      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/fresh": {
@@ -9717,6 +9770,18 @@
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true
     },
+    "node_modules/ssf": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
+      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "frac": "~1.1.2"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/stack-utils": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
@@ -10757,6 +10822,24 @@
         "node": ">=8.12.0"
       }
     },
+    "node_modules/wmf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
+      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/word": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
+      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -10819,6 +10902,27 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xlsx": {
+      "version": "0.18.5",
+      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
+      "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "cfb": "~1.2.1",
+        "codepage": "~1.15.0",
+        "crc-32": "~1.2.1",
+        "ssf": "~0.11.2",
+        "wmf": "~1.0.1",
+        "word": "~0.3.0"
+      },
+      "bin": {
+        "xlsx": "bin/xlsx.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/xmlhttprequest-ssl": {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.2.0",
     "socket.io-client": "^4.7.5",
-    "uuid": "^11.0.5"
+    "uuid": "^11.0.5",
+    "xlsx": "^0.18.5"
   },
   "devDependencies": {
     "@nestjs/cli": "^9.0.0",

--- a/src/auth/rest-jwt-auth-guard.ts
+++ b/src/auth/rest-jwt-auth-guard.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+
+/**
+ * REST-flavoured JWT guard.
+ *
+ * The app's primary `JwtAuthGuard` overrides `getRequest()` to pull the request
+ * out of the **GraphQL** execution context — so it throws on a plain HTTP route.
+ * REST controllers (the bulk DI import endpoint) need the default passport
+ * behaviour, which reads the request from `switchToHttp()`. The shared
+ * `passport-jwt` strategy (Bearer token → `{ _id, ... }` on `req.user`) is
+ * reused as-is; only the context extraction differs, hence this thin subclass.
+ */
+@Injectable()
+export class RestJwtAuthGuard extends AuthGuard('jwt') {}

--- a/src/di/di-ref-format.spec.ts
+++ b/src/di/di-ref-format.spec.ts
@@ -1,0 +1,100 @@
+// nanoid is ESM-only → mock so importing DiService doesn't blow up under jest.
+jest.mock('nanoid', () => ({ nanoid: () => 'rand' }));
+
+import { DiService } from './di.service';
+
+/**
+ * DI reference format: `DI{n}` → `T{n}` (e.g. T1562).
+ *  - the NUMBER keeps incrementing across the rename (max of DI{n} ∪ T{n} + 1),
+ *  - existing legacy `DI{n}` rows are never rewritten,
+ *  - `_id` stays a random `DI_<nanoid>` (it's not the human reference).
+ *
+ * Built with `Object.create(DiService.prototype)` + manual mock fields so we
+ * skip the 16-arg constructor (same pattern as di.resolve-drive-target.spec).
+ */
+
+function svcWithIds(rows: Array<{ _idnum: string }>) {
+  const s: any = Object.create(DiService.prototype);
+  s.diModel = {
+    find: jest.fn().mockReturnValue({ lean: () => Promise.resolve(rows) }),
+  };
+  return s;
+}
+
+describe('DI reference — generateClientId (next number, DI ∪ T)', () => {
+  it('continues from the last legacy DI{n} (DI1561 → 1562)', async () => {
+    const s = svcWithIds([{ _idnum: 'DI1560' }, { _idnum: 'DI1561' }]);
+    expect(await s.generateClientId()).toBe(1562);
+  });
+
+  it('counts existing T{n} refs so a new one never collides', async () => {
+    const s = svcWithIds([
+      { _idnum: 'DI1561' },
+      { _idnum: 'T1562' },
+      { _idnum: 'T1563' },
+    ]);
+    expect(await s.generateClientId()).toBe(1564);
+  });
+
+  it('ignores junk ids (INMAG-/DINaN), never NaN', async () => {
+    const s = svcWithIds([
+      { _idnum: 'INMAG-xy' },
+      { _idnum: 'T7' },
+      { _idnum: 'DINaN' },
+    ]);
+    const n = await s.generateClientId();
+    expect(n).toBe(8);
+    expect(Number.isNaN(n)).toBe(false);
+  });
+});
+
+describe('DI reference — createDi assigns T{n}, leaves existing untouched', () => {
+  function buildSvc(existing: Array<{ _idnum: string }>) {
+    let saved: any = null;
+    function DiModel(this: any, input: any) {
+      Object.assign(this, input);
+    }
+    DiModel.prototype.save = async function () {
+      saved = this;
+      return this;
+    };
+    (DiModel as any).find = jest
+      .fn()
+      .mockReturnValue({ lean: () => Promise.resolve(existing) });
+
+    const svc: any = Object.create(DiService.prototype);
+    svc.diModel = DiModel;
+    svc.syncEmplacementStats = jest.fn().mockResolvedValue(undefined);
+    svc.discordHookService = { sendDiPendingNotification: jest.fn() };
+    svc.operationalErrorService = { capture: jest.fn() };
+    return { svc, getSaved: () => saved };
+  }
+
+  it('new DI gets a T{n} ref continuing the max (DI1561 → T1562); _id stays random', async () => {
+    const { svc, getSaved } = buildSvc([{ _idnum: 'DI1561' }]);
+    const di = await svc.createDi({ status: 'CREATED', location_id: 'L1', title: 'x' });
+    expect(di._idnum).toBe('T1562');
+    expect(getSaved()._idnum).toBe('T1562');
+    expect(String(di._id)).toMatch(/^DI_/); // random id, NOT the reference
+  });
+
+  it('next creation increments (… T1562 present → T1563)', async () => {
+    const { svc } = buildSvc([{ _idnum: 'DI1561' }, { _idnum: 'T1562' }]);
+    const di = await svc.createDi({ status: 'CREATED', location_id: 'L1' });
+    expect(di._idnum).toBe('T1563');
+  });
+
+  it('existing legacy DIs are NOT rewritten (only the new ref is inserted)', async () => {
+    const existing = [{ _idnum: 'DI0' }, { _idnum: 'DI1561' }];
+    const { svc } = buildSvc(existing);
+    await svc.createDi({ status: 'CREATED', location_id: 'L1' });
+    expect(existing).toEqual([{ _idnum: 'DI0' }, { _idnum: 'DI1561' }]);
+  });
+
+  it('no zero-padding (T1562, not T01562)', async () => {
+    const { svc } = buildSvc([{ _idnum: 'DI1561' }]);
+    const di = await svc.createDi({ status: 'CREATED', location_id: 'L1' });
+    expect(di._idnum).toBe('T1562');
+    expect(di._idnum).not.toMatch(/T0\d/);
+  });
+});

--- a/src/di/di.module.ts
+++ b/src/di/di.module.ts
@@ -31,8 +31,13 @@ import { DiscordHookModule } from 'src/discord-hook/discord-hook.module';
 import { DiWorkflowService } from './workflow/di-workflow.service';
 import { OperationalErrorModule } from 'src/operational-error/operational-error.module';
 import { GoogleDriveModule } from 'src/google-drive/google-drive.module';
+import { ClientsModule } from 'src/clients/clients.module';
+import { LocationModule } from 'src/location/location.module';
+import { DiImportController } from './import/di-import.controller';
+import { DiImportService } from './import/di-import.service';
 
 @Module({
+  controllers: [DiImportController],
   providers: [
     DiResolver,
     DiService,
@@ -40,6 +45,7 @@ import { GoogleDriveModule } from 'src/google-drive/google-drive.module';
     NotificationsGateway,
     ProfileService,
     DiWorkflowService,
+    DiImportService,
   ],
   imports: [
     DiscordHookModule,
@@ -48,6 +54,8 @@ import { GoogleDriveModule } from 'src/google-drive/google-drive.module';
     LogsDiModule,
     OperationalErrorModule,
     GoogleDriveModule,
+    ClientsModule,
+    LocationModule,
     MongooseModule.forFeature([
       {
         name: Di.name,

--- a/src/di/di.service.ts
+++ b/src/di/di.service.ts
@@ -415,31 +415,61 @@ export class DiService {
   }
 
   /**
-   * Next DI number for the `_idnum` (`DI{n}`). HARDENED: only `_idnum` matching
-   * `^DI\d+$` count — QA/legacy junk ids (`INMAG-…`, `LIFE-…`, even a previous
-   * `DINaN`) are IGNORED so the parse can never yield `NaN`. Next = max(valid)+1,
-   * fallback 1 when none. The old version read the most-recent DI's `_idnum` and
-   * did `+substring(2)`; a single non-conforming id there produced `DINaN` and
-   * poisoned every subsequent creation.
+   * Next DI number for `_idnum`. New refs use the `T{n}` format, but legacy DIs
+   * carry the old `DI{n}` — so the next number is `max(both)+1`, letting the
+   * sequence CONTINUE seamlessly across the rename (e.g. last `DI1561` → next
+   * `T1562`) and guaranteeing a fresh `T{n}` never collides with an earlier one.
+   *
+   * HARDENED: only ids matching `^(DI|T)\d+$` count — QA/legacy junk ids
+   * (`INMAG-…`, `LIFE-…`, even a previous `DINaN`) are IGNORED so the parse can
+   * never yield `NaN`. Next = max(valid)+1, fallback 1 when none.
+   *
+   * NOTE: this remains a `max+1` read (not an atomic counter). Two strictly
+   * simultaneous creations could in theory read the same max — acceptable at
+   * this volume; switch to a `counters` doc + `$inc` if that ever bites.
    */
   async generateClientId(): Promise<number> {
     const rows = await this.diModel
-      .find({ _idnum: { $regex: '^DI[0-9]+$' } }, { _idnum: 1 })
+      .find({ _idnum: { $regex: '^(DI|T)[0-9]+$' } }, { _idnum: 1 })
       .lean();
     let max = 0;
     for (const r of rows) {
-      const n = parseInt(String((r as any)?._idnum).slice(2), 10);
+      // Strip the prefix (DI or T) and read the trailing number; non-matching
+      // ids are skipped (never NaN-poison the max).
+      const m = String((r as any)?._idnum ?? '').match(/^(?:DI|T)(\d+)$/);
+      if (!m) continue;
+      const n = parseInt(m[1], 10);
       if (Number.isFinite(n) && n > max) max = n;
     }
-    return max + 1; // ≥ 1 → never `DI` + `NaN`, never collides with the max
+    return max + 1; // ≥ 1 → never collides with the current max
   }
 
-  async createDi(createDiInput: CreateDiInput): Promise<any> {
+  /**
+   * Create one DI.
+   *
+   * `opts` exists for the bulk .xlsx import (the only other caller):
+   *  - `forcedRef`  — use this exact `_idnum` (taken AS-IS from the imported
+   *    file, e.g. `T1394`) INSTEAD of `generateClientId()`. The auto counter is
+   *    never read nor advanced, so importing a backlog leaves the live sequence
+   *    untouched. The caller is responsible for collision/format checks.
+   *  - `skipNotify` — suppress the Discord "pending" ping (a bulk import would
+   *    otherwise fire one webhook per row). Normal single creation keeps it on.
+   */
+  async createDi(
+    createDiInput: CreateDiInput,
+    opts?: { forcedRef?: string; skipNotify?: boolean },
+  ): Promise<any> {
     try {
-      // 🆔 Generate IDs
-      const index = await this.generateClientId();
+      // 🆔 Generate IDs. `_id` stays a random unique key (`DI_<nanoid>`); the
+      // human reference `_idnum` now uses the **`T{num}`** format (e.g. T1562)
+      // — unless the import forces a specific ref taken from the file.
       createDiInput._id = `DI_${nanoid(4)}`;
-      createDiInput._idnum = `DI${index}`;
+      if (opts?.forcedRef) {
+        createDiInput._idnum = opts.forcedRef;
+      } else {
+        const index = await this.generateClientId();
+        createDiInput._idnum = `T${index}`;
+      }
 
       // 🖼️ Handle image — uploaded to the DI's entity Drive folder (Drive-only,
       // no local docs/). BEST-EFFORT here: an upload failure must NOT block DI
@@ -480,8 +510,9 @@ export class DiService {
       const di = await diDoc.save();
       await this.syncEmplacementStats(di.location_id as any);
 
-      // 🔔 Notify (only if pending)
-      if (di.status === 'PENDING1') {
+      // 🔔 Notify (only if pending) — skipped for bulk import to avoid one
+      // Discord webhook per imported row.
+      if (!opts?.skipNotify && di.status === 'PENDING1') {
         this.discordHookService.sendDiPendingNotification(di);
       }
 

--- a/src/di/dto/create-di.input.ts
+++ b/src/di/dto/create-di.input.ts
@@ -39,6 +39,10 @@ export class CreateDiInput {
   company_id: string;
   @Field({ nullable: true })
   nSerie: string;
+  // « Date de réception » — only set by the bulk .xlsx import (backlog DIs keep
+  // their original reception date). Normal creation leaves it undefined.
+  @Field({ nullable: true })
+  dateReception: Date;
   @Field({ nullable: true })
   price: number;
   @Field({ nullable: true })

--- a/src/di/entities/di.entity.ts
+++ b/src/di/entities/di.entity.ts
@@ -22,6 +22,11 @@ export class DiDocument extends Document {
   description: string;
   @Prop()
   nSerie: string;
+  // Date the equipment was physically received (« Date de réception »). Added
+  // for the bulk .xlsx import (backlog DIs carry their original reception date);
+  // optional for normal creation, which leaves it null.
+  @Prop({ default: null })
+  dateReception: Date | null;
   @Prop()
   // repair or not
   can_be_repaired: boolean;
@@ -229,6 +234,10 @@ export class Di {
   title: string;
   @Field({ nullable: true })
   nSerie: string;
+  // Physical reception date (« Date de réception ») — populated by the bulk
+  // import; null for DIs created through the normal flow.
+  @Field({ nullable: true })
+  dateReception?: Date;
   @Field({ nullable: true })
   confirmationComposant: string;
   @Field({ nullable: true })

--- a/src/di/import/di-import.controller.ts
+++ b/src/di/import/di-import.controller.ts
@@ -1,0 +1,71 @@
+import {
+  BadRequestException,
+  Controller,
+  Get,
+  Post,
+  Query,
+  Req,
+  Res,
+  UploadedFile,
+  UseGuards,
+  UseInterceptors,
+} from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
+import { Request, Response } from 'express';
+import { RestJwtAuthGuard } from 'src/auth/rest-jwt-auth-guard';
+import { DiImportService } from './di-import.service';
+
+/**
+ * REST surface for the bulk DI import (multipart — outside GraphQL).
+ *
+ *   POST /di/import?dryRun=true|false   multipart field `file` (.xlsx)
+ *   GET  /di/import/template            streams the .xlsx model
+ *
+ * Auth: `RestJwtAuthGuard` (Bearer token, same as the GraphQL API). The import
+ * never notifies Discord (handled in the service via `skipNotify`), so there is
+ * no `x-test-run` side-effect to suppress here.
+ */
+@Controller('di')
+export class DiImportController {
+  constructor(private readonly importService: DiImportService) {}
+
+  @Post('import')
+  @UseGuards(RestJwtAuthGuard)
+  @UseInterceptors(
+    FileInterceptor('file', {
+      // In-memory (default) — a backlog import is small. 8 MB hard cap.
+      limits: { fileSize: 8 * 1024 * 1024, files: 1 },
+    }),
+  )
+  async import(
+    @UploadedFile() file: { originalname?: string; buffer?: Buffer } | undefined,
+    @Query('dryRun') dryRun: string,
+    @Req() req: Request,
+  ) {
+    if (!file || !file.buffer) {
+      throw new BadRequestException('Fichier manquant (champ « file »).');
+    }
+    if (!/\.xlsx$/i.test(file.originalname ?? '')) {
+      throw new BadRequestException('Format invalide : un fichier .xlsx est attendu.');
+    }
+    // Default to the SAFE dry-run; only an explicit `dryRun=false` persists.
+    const isDryRun = String(dryRun) !== 'false';
+    const createdBy = (req as any)?.user?._id;
+    return this.importService.run(file.buffer, { dryRun: isDryRun, createdBy });
+  }
+
+  @Get('import/template')
+  @UseGuards(RestJwtAuthGuard)
+  template(@Res() res: Response) {
+    const buffer = this.importService.buildTemplate();
+    res.setHeader(
+      'Content-Type',
+      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    );
+    res.setHeader(
+      'Content-Disposition',
+      'attachment; filename="modele_import_di.xlsx"',
+    );
+    res.send(buffer);
+  }
+}

--- a/src/di/import/di-import.service.spec.ts
+++ b/src/di/import/di-import.service.spec.ts
@@ -1,0 +1,255 @@
+// DiService (imported transitively) pulls in nanoid, which is ESM-only and
+// blows up under jest unless mocked — same guard as the other DI specs.
+jest.mock('nanoid', () => ({ nanoid: () => 'rand' }));
+
+import * as XLSX from 'xlsx';
+import { DiImportService } from './di-import.service';
+
+/**
+ * Unit tests for the bulk DI import.
+ *
+ * Fixtures are real .xlsx buffers built in-test with SheetJS, with the header
+ * deliberately on **row 4** (three blank rows above) to prove label-based
+ * detection. All collaborators are mocked: nothing hits Mongo, Drive or Discord.
+ *
+ * Guards:
+ *  - dry-run counts valid rows and persists NOTHING
+ *  - import creates DIs with the EXACT file ref (forcedRef, generator bypassed)
+ *  - existing ref → row error, never overwritten
+ *  - intra-file duplicate ref → row error
+ *  - same client across rows → a single auto-creation
+ *  - missing mandatory column → global reject, 0 processed
+ *  - ref in the auto-generation zone → non-blocking warning
+ *  - numeric serial → string; DD/MM/YYYY parsed without TZ offset
+ */
+
+const HEADERS = ['N° DI', 'Désignation', 'N° Série', 'Client', 'Date de réception', 'Rangement'];
+
+/** Build an .xlsx buffer with `headers` on Excel row `headerRow` (1-based). */
+function buildXlsx(
+  headers: any[],
+  dataRows: any[][],
+  headerRow = 4,
+): Buffer {
+  const aoa: any[][] = [];
+  for (let i = 0; i < headerRow - 1; i++) aoa.push([]); // blank rows above
+  aoa.push(headers);
+  for (const r of dataRows) aoa.push(r);
+  const ws = XLSX.utils.aoa_to_sheet(aoa);
+  const wb = XLSX.utils.book_new();
+  XLSX.utils.book_append_sheet(wb, ws, 'DI');
+  return XLSX.write(wb, { type: 'buffer', bookType: 'xlsx' });
+}
+
+type ModelMock = { find: jest.Mock };
+const findReturning = (rows: any[]): ModelMock => ({
+  find: jest.fn().mockReturnValue({ lean: () => Promise.resolve(rows) }),
+});
+
+interface Deps {
+  diModel: ModelMock;
+  clientModel: ModelMock;
+  locationModel: ModelMock;
+  diService: { createDi: jest.Mock };
+  clientsService: { createClient: jest.Mock };
+  locationService: { createlocation: jest.Mock };
+}
+
+function makeService(over: Partial<{ existingDi: any[]; clients: any[]; locations: any[] }> = {}) {
+  let clientSeq = 0;
+  let locSeq = 0;
+  const deps: Deps = {
+    diModel: findReturning(over.existingDi ?? []),
+    clientModel: findReturning(over.clients ?? []),
+    locationModel: findReturning(over.locations ?? []),
+    diService: { createDi: jest.fn().mockResolvedValue({ _id: 'DI_rand' }) },
+    clientsService: {
+      createClient: jest
+        .fn()
+        .mockImplementation(async (i: any) => ({ _id: `C${++clientSeq}`, ...i })),
+    },
+    locationService: {
+      createlocation: jest
+        .fn()
+        .mockImplementation(async (i: any) => ({ _id: `L${++locSeq}`, ...i })),
+    },
+  };
+  const svc = new DiImportService(
+    deps.diModel as any,
+    deps.clientModel as any,
+    deps.locationModel as any,
+    deps.diService as any,
+    deps.clientsService as any,
+    deps.locationService as any,
+  );
+  return { svc, deps };
+}
+
+describe('DiImportService — dry-run', () => {
+  it('detects the row-4 header, counts valid rows, and persists NOTHING', async () => {
+    const { svc, deps } = makeService();
+    const buf = buildXlsx(HEADERS, [
+      ['T1394', 'AGRO NADHOUR', '***', 'COGEMHY', '18/06/2026', 'A28'],
+      ['T1345', 'CARTE FOUR', '4821810100', 'PERSO (PROMODAR)', '04/05/2026', 'A15'],
+    ]);
+    const report = await svc.run(buf, { dryRun: true });
+
+    expect(report.ligneEnTete).toBe(4);
+    expect(report.total).toBe(2);
+    expect(report.valides).toBe(2);
+    expect(report.erreurs).toHaveLength(0);
+    expect(report.crees).toBeUndefined();
+    // Nothing persisted in dry-run.
+    expect(deps.diService.createDi).not.toHaveBeenCalled();
+    expect(deps.clientsService.createClient).not.toHaveBeenCalled();
+  });
+
+  it('flags missing required values per row with the real Excel line number', async () => {
+    const { svc } = makeService();
+    const buf = buildXlsx(HEADERS, [
+      ['', 'NO REF', '***', 'ACME', '', ''], // line 5: missing N° DI
+      ['T1', '', '***', 'ACME', '', ''], // line 6: missing Désignation
+      ['T2', 'OK', '***', '', '', ''], // line 7: missing Client
+    ]);
+    const report = await svc.run(buf, { dryRun: true });
+    expect(report.total).toBe(3);
+    expect(report.valides).toBe(0);
+    expect(report.erreurs.map((e) => e.ligne)).toEqual([5, 6, 7]);
+  });
+});
+
+describe('DiImportService — import (dryRun=false)', () => {
+  it('creates DIs with the EXACT file ref (forcedRef) + skipNotify, generator bypassed', async () => {
+    const { svc, deps } = makeService({ existingDi: [{ _idnum: 'T1000' }] });
+    const buf = buildXlsx(HEADERS, [
+      ['T1394', 'AGRO NADHOUR', '***', 'COGEMHY', '18/06/2026', 'A28'],
+    ]);
+    const report = await svc.run(buf, { dryRun: false, createdBy: 'PROFILE_1' });
+
+    expect(report.crees).toEqual({ dis: 1, clients: 1, locations: 1, ignorees: 0 });
+    expect(deps.diService.createDi).toHaveBeenCalledTimes(1);
+    const [input, opts] = deps.diService.createDi.mock.calls[0];
+    expect(opts).toEqual({ forcedRef: 'T1394', skipNotify: true });
+    expect(input).toEqual(
+      expect.objectContaining({
+        title: 'AGRO NADHOUR',
+        nSerie: '***',
+        type_client: 'Client',
+        status: 'CREATED',
+        createdBy: 'PROFILE_1',
+      }),
+    );
+  });
+
+  it('normalises a numeric serial to a string and parses DD/MM/YYYY without TZ offset', async () => {
+    const { svc, deps } = makeService();
+    const buf = buildXlsx(HEADERS, [
+      // 4821810100 written as a real NUMBER cell; date as DD/MM/YYYY text.
+      ['T1345', 'CARTE FOUR', 4821810100, 'PERSO', '04/05/2026', 'A15'],
+    ]);
+    await svc.run(buf, { dryRun: false });
+    const [input] = deps.diService.createDi.mock.calls[0];
+    expect(input.nSerie).toBe('4821810100');
+    expect(input.dateReception).toBeInstanceOf(Date);
+    expect(input.dateReception.toISOString().slice(0, 10)).toBe('2026-05-04');
+  });
+
+  it('auto-creates a client once when it recurs across rows; links Rangement → location', async () => {
+    const { svc, deps } = makeService();
+    const buf = buildXlsx(HEADERS, [
+      ['T1', 'A', '***', 'COGEMHY', '', 'A28'],
+      ['T2', 'B', '***', 'cogemhy', '', 'A28'], // same client (case-insensitive)
+    ]);
+    const report = await svc.run(buf, { dryRun: false });
+
+    expect(report.crees).toEqual({ dis: 2, clients: 1, locations: 1, ignorees: 0 });
+    expect(deps.clientsService.createClient).toHaveBeenCalledTimes(1);
+    expect(deps.locationService.createlocation).toHaveBeenCalledTimes(1);
+    // Both DIs point at the same auto-created client + location.
+    const ids = deps.diService.createDi.mock.calls.map((c) => c[0].client_id);
+    expect(ids[0]).toBe(ids[1]);
+  });
+
+  it('reuses an EXISTING client/location instead of creating duplicates', async () => {
+    const { svc, deps } = makeService({
+      clients: [{ _id: 'C9', first_name: 'COGEMHY', last_name: '' }],
+      locations: [{ _id: 'L9', location_name: 'A28' }],
+    });
+    const buf = buildXlsx(HEADERS, [['T1', 'A', '***', 'COGEMHY', '', 'A28']]);
+    const report = await svc.run(buf, { dryRun: false });
+
+    expect(report.crees).toEqual({ dis: 1, clients: 0, locations: 0, ignorees: 0 });
+    expect(deps.clientsService.createClient).not.toHaveBeenCalled();
+    const [input] = deps.diService.createDi.mock.calls[0];
+    expect(input.client_id).toBe('C9');
+    expect(input.location_id).toBe('L9');
+  });
+});
+
+describe('DiImportService — collisions & guards', () => {
+  it('marks a row whose ref already exists in DB as an error and never persists it', async () => {
+    const { svc, deps } = makeService({ existingDi: [{ _idnum: 'T1394' }] });
+    const buf = buildXlsx(HEADERS, [
+      ['T1394', 'DUP', '***', 'ACME', '', ''],
+      ['T1395', 'OK', '***', 'ACME', '', ''],
+    ]);
+    const report = await svc.run(buf, { dryRun: false });
+
+    expect(report.erreurs).toHaveLength(1);
+    expect(report.erreurs[0].ligne).toBe(5);
+    expect(report.erreurs[0].motifs[0]).toMatch(/déjà existant/i);
+    expect(report.crees!.dis).toBe(1); // only T1395 imported
+    const refs = deps.diService.createDi.mock.calls.map((c) => c[1].forcedRef);
+    expect(refs).toEqual(['T1395']);
+  });
+
+  it('marks intra-file duplicate refs as errors (both rows)', async () => {
+    const { svc, deps } = makeService();
+    const buf = buildXlsx(HEADERS, [
+      ['T5', 'A', '***', 'ACME', '', ''],
+      ['T5', 'B', '***', 'ACME', '', ''],
+    ]);
+    const report = await svc.run(buf, { dryRun: false });
+
+    expect(report.erreurs.map((e) => e.ligne).sort()).toEqual([5, 6]);
+    expect(report.crees!.dis).toBe(0);
+    expect(deps.diService.createDi).not.toHaveBeenCalled();
+  });
+
+  it('global-rejects a file whose header misses a mandatory column (0 processed)', async () => {
+    const { svc, deps } = makeService();
+    // No "Client" column.
+    const buf = buildXlsx(['N° DI', 'Désignation', 'N° Série', 'Rangement'], [
+      ['T1', 'A', '***', 'A28'],
+    ]);
+    const report = await svc.run(buf, { dryRun: false });
+
+    expect(report.enTeteInvalide).toBe(true);
+    expect(report.ligneEnTete).toBeNull();
+    expect(report.total).toBe(0);
+    expect(report.erreurs[0].motifs[0]).toMatch(/en-tête introuvable/i);
+    expect(deps.diService.createDi).not.toHaveBeenCalled();
+  });
+
+  it('warns (non-blocking) when a ref lands in the auto-generation zone', async () => {
+    const { svc } = makeService({ existingDi: [{ _idnum: 'T2000' }] }); // nextAuto = 2001
+    const buf = buildXlsx(HEADERS, [
+      ['T1394', 'BACKFILL', '***', 'ACME', '', ''], // 1394 < 2001 → safe, no warn
+      ['T2050', 'FUTURE', '***', 'ACME', '', ''], // 2050 ≥ 2001 → warn
+    ]);
+    const report = await svc.run(buf, { dryRun: true });
+
+    expect(report.valides).toBe(2); // warnings never block
+    const warnLines = report.warnings.filter((w) => /auto-générée/i.test(w.message));
+    expect(warnLines).toHaveLength(1);
+    expect(warnLines[0].ligne).toBe(6);
+  });
+
+  it('warns on an unexpected ref format but still imports the row', async () => {
+    const { svc } = makeService();
+    const buf = buildXlsx(HEADERS, [['ABC-9', 'WEIRD', '***', 'ACME', '', '']]);
+    const report = await svc.run(buf, { dryRun: true });
+    expect(report.valides).toBe(1);
+    expect(report.warnings.some((w) => /inhabituel/i.test(w.message))).toBe(true);
+  });
+});

--- a/src/di/import/di-import.service.ts
+++ b/src/di/import/di-import.service.ts
@@ -1,0 +1,554 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import * as XLSX from 'xlsx';
+import { DiService } from '../di.service';
+import { ClientsService } from 'src/clients/clients.service';
+import { LocationService } from 'src/location/location.service';
+
+/**
+ * Bulk DI import from an .xlsx file — two-phase (dry-run preview → real import).
+ *
+ * Source columns (header detected BY LABEL, not by position — the real export
+ * carries 3 blank title rows so the header sits on row 4):
+ *   N° DI | Désignation | N° Série | Client | Date de réception | Rangement
+ *
+ * Mapping (see the discovery report):
+ *   N° DI            → _idnum   (taken AS-IS from the file; the auto counter is
+ *                                 NEVER read nor advanced)
+ *   Désignation      → title
+ *   N° Série         → nSerie   (normalised to a trimmed string; `***`/empty ok)
+ *   Client           → client_id (resolved by name, auto-created, idempotent)
+ *   Date de réception→ dateReception (DD/MM/YYYY or Excel serial)
+ *   Rangement        → location_id (Location resolved by name, find-or-create)
+ *   TYPE (absent)    → type_client defaults to 'Client'
+ *
+ * Policy: invalid rows are IGNORED and reported (not all-or-nothing). Existing
+ * refs are NEVER overwritten.
+ */
+
+export interface ImportWarning {
+  ligne: number;
+  message: string;
+}
+export interface ImportError {
+  ligne: number;
+  valeurs: Record<string, string>;
+  motifs: string[];
+}
+export interface ImportCrees {
+  dis: number;
+  clients: number;
+  locations: number;
+  ignorees: number;
+}
+export type LigneStatut = 'valide' | 'avertissement' | 'erreur';
+/** One processed data row, for the colored preview table on the front. */
+export interface ImportLigne {
+  ligne: number;
+  statut: LigneStatut;
+  valeurs: Record<string, string>;
+  motifs: string[];
+}
+export interface ImportReport {
+  ligneEnTete: number | null;
+  total: number;
+  valides: number;
+  warnings: ImportWarning[];
+  erreurs: ImportError[];
+  /** Every non-blank row with its computed status — drives the FE preview. */
+  lignes: ImportLigne[];
+  /** Set only on a header/structure global reject so the FE can toast cleanly. */
+  enTeteInvalide?: boolean;
+  /** Present only on a real import (dryRun=false). */
+  crees?: ImportCrees;
+}
+
+/** The six logical columns. nDi/designation/nSerie/client are MANDATORY columns. */
+type ColKey = 'nDi' | 'designation' | 'nSerie' | 'client' | 'date' | 'rangement';
+
+const MANDATORY_COLS: ColKey[] = ['nDi', 'designation', 'nSerie', 'client'];
+
+// Header label aliases (already normalised: lower-case, accent-stripped, single
+// spaces). Matching is exact against a normalised header cell, so order/case/
+// accents/punctuation in the file don't matter.
+const COL_ALIASES: Record<ColKey, string[]> = {
+  nDi: ['n di', 'no di', 'numero di', 'num di', 'ndi', 'n di t', 'reference', 'ref'],
+  designation: ['designation', 'desgination', 'libelle', 'intitule', 'denomination'],
+  nSerie: ['n serie', 'no serie', 'numero serie', 'num serie', 'nserie', 'serie', 'numero de serie', 's n', 'sn'],
+  client: ['client', 'clients', 'nom client', 'societe client', 'raison sociale'],
+  date: ['date de reception', 'date reception', 'date recue', 'date recu', 'reception', 'date'],
+  rangement: ['rangement', 'emplacement', 'localisation', 'location', 'position'],
+};
+
+// Human labels reused for the template + error reporting.
+export const TEMPLATE_HEADERS = [
+  'N° DI',
+  'Désignation',
+  'N° Série',
+  'Client',
+  'Date de réception',
+  'Rangement',
+];
+
+interface ParsedRow {
+  ligne: number; // real 1-based Excel row
+  nDi: string;
+  designation: string;
+  nSerie: string;
+  clientName: string;
+  rangement: string;
+  dateValue: Date | null;
+  raw: Record<string, string>; // original cell strings, for error echo
+}
+
+@Injectable()
+export class DiImportService {
+  private readonly logger = new Logger(DiImportService.name);
+
+  constructor(
+    @InjectModel('Di') private readonly diModel: Model<any>,
+    @InjectModel('Client') private readonly clientModel: Model<any>,
+    @InjectModel('Location') private readonly locationModel: Model<any>,
+    private readonly diService: DiService,
+    private readonly clientsService: ClientsService,
+    private readonly locationService: LocationService,
+  ) {}
+
+  // ---------------------------------------------------------------------------
+  // Public entrypoints
+  // ---------------------------------------------------------------------------
+
+  /** Parse + validate; when dryRun is false, also persist the valid rows. */
+  async run(
+    buffer: Buffer,
+    opts: { dryRun: boolean; createdBy?: string },
+  ): Promise<ImportReport> {
+    const parsed = this.parse(buffer);
+    if (parsed.enTeteInvalide) return parsed.report; // global reject, 0 processed
+
+    const existing = await this.loadExistingRefs();
+    const report = this.validate(parsed.rows, existing);
+    report.ligneEnTete = parsed.headerLine;
+
+    if (opts.dryRun) return report;
+
+    // Real import — persist only the rows flagged valid by `validate`.
+    const crees = await this.persist(parsed.rows, report, opts.createdBy);
+    report.crees = crees;
+    return report;
+  }
+
+  /** Build the downloadable .xlsx model (headers + two example rows). */
+  buildTemplate(): Buffer {
+    const rows = [
+      TEMPLATE_HEADERS,
+      ['T1394', 'AGRO NADHOUR', '***', 'COGEMHY', '18/06/2026', 'A28'],
+      ['T1345', 'CARTE FOUR', '4821810100', 'PERSO (PROMODAR)', '04/05/2026', 'A15'],
+    ];
+    const ws = XLSX.utils.aoa_to_sheet(rows);
+    ws['!cols'] = [{ wch: 10 }, { wch: 24 }, { wch: 14 }, { wch: 22 }, { wch: 18 }, { wch: 12 }];
+    const wb = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(wb, ws, 'DI');
+    return XLSX.write(wb, { type: 'buffer', bookType: 'xlsx' });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Parsing — header detection by label + row extraction with real line numbers
+  // ---------------------------------------------------------------------------
+
+  private parse(buffer: Buffer): {
+    rows: ParsedRow[];
+    headerLine: number | null;
+    enTeteInvalide: boolean;
+    report: ImportReport;
+  } {
+    const empty = (msg: string): any => ({
+      rows: [],
+      headerLine: null,
+      enTeteInvalide: true,
+      report: {
+        ligneEnTete: null,
+        total: 0,
+        valides: 0,
+        warnings: [],
+        erreurs: [{ ligne: 0, valeurs: {}, motifs: [msg] }],
+        lignes: [],
+        enTeteInvalide: true,
+      },
+    });
+
+    let wb: XLSX.WorkBook;
+    try {
+      wb = XLSX.read(buffer, { type: 'buffer', cellDates: true });
+    } catch {
+      return empty('Fichier illisible : .xlsx valide attendu.');
+    }
+    const sheetName = wb.SheetNames[0];
+    const sheet = sheetName ? wb.Sheets[sheetName] : undefined;
+    if (!sheet || !sheet['!ref']) {
+      return empty('Feuille vide : aucune donnée détectée.');
+    }
+    const range = XLSX.utils.decode_range(sheet['!ref']);
+    const cell = (r: number, c: number): any => {
+      const ref = XLSX.utils.encode_cell({ r, c });
+      const cl = (sheet as any)[ref];
+      return cl ? cl.v : null;
+    };
+
+    // 1) Locate the header row: the first row that carries ALL mandatory labels.
+    let headerRow = -1;
+    let cols: Partial<Record<ColKey, number>> = {};
+    for (let r = range.s.r; r <= range.e.r; r++) {
+      const found = this.matchHeader(cell, r, range);
+      if (found && MANDATORY_COLS.every((k) => found[k] != null)) {
+        headerRow = r;
+        cols = found;
+        break;
+      }
+    }
+    if (headerRow === -1) {
+      return empty(
+        'En-tête introuvable : colonnes obligatoires manquantes (N° DI, Désignation, N° Série, Client).',
+      );
+    }
+
+    // 2) Extract data rows (real 1-based Excel line = r + 1). Blank rows skipped.
+    const rows: ParsedRow[] = [];
+    for (let r = headerRow + 1; r <= range.e.r; r++) {
+      const get = (k: ColKey): any =>
+        cols[k] != null ? cell(r, cols[k] as number) : null;
+
+      const nDi = this.str(get('nDi'));
+      const designation = this.str(get('designation'));
+      const nSerie = this.str(get('nSerie'));
+      const clientName = this.str(get('client'));
+      const rangement = this.str(get('rangement'));
+      const dateRaw = get('date');
+
+      // Fully blank row → skip silently (don't count toward total).
+      if (!nDi && !designation && !nSerie && !clientName && !rangement && (dateRaw == null || dateRaw === '')) {
+        continue;
+      }
+
+      rows.push({
+        ligne: r + 1,
+        nDi,
+        designation,
+        nSerie,
+        clientName,
+        rangement,
+        dateValue: this.parseDate(dateRaw),
+        raw: {
+          'N° DI': nDi,
+          Désignation: designation,
+          'N° Série': nSerie,
+          Client: clientName,
+          'Date de réception': this.str(dateRaw),
+          Rangement: rangement,
+        },
+      });
+    }
+
+    return {
+      rows,
+      headerLine: headerRow + 1,
+      enTeteInvalide: false,
+      report: null as any,
+    };
+  }
+
+  /** Try to resolve every column index from a candidate header row. */
+  private matchHeader(
+    cell: (r: number, c: number) => any,
+    r: number,
+    range: XLSX.Range,
+  ): Partial<Record<ColKey, number>> {
+    const cols: Partial<Record<ColKey, number>> = {};
+    for (let c = range.s.c; c <= range.e.c; c++) {
+      const nv = this.norm(cell(r, c));
+      if (!nv) continue;
+      for (const key of Object.keys(COL_ALIASES) as ColKey[]) {
+        if (cols[key] != null) continue;
+        if (COL_ALIASES[key].includes(nv)) {
+          cols[key] = c;
+          break;
+        }
+      }
+    }
+    return cols;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Validation
+  // ---------------------------------------------------------------------------
+
+  private validate(
+    rows: ParsedRow[],
+    existing: { refs: Set<string>; nextAuto: number },
+  ): ImportReport {
+    // Intra-file duplicate detection (case-sensitive on the exact ref string).
+    const seen = new Map<string, number>();
+    for (const row of rows) {
+      if (!row.nDi) continue;
+      seen.set(row.nDi, (seen.get(row.nDi) ?? 0) + 1);
+    }
+
+    const warnings: ImportWarning[] = [];
+    const erreurs: ImportError[] = [];
+    const lignes: ImportLigne[] = [];
+    let valides = 0;
+
+    for (const row of rows) {
+      const motifs: string[] = [];
+
+      if (!row.nDi) motifs.push('N° DI manquant');
+      if (!row.designation) motifs.push('Désignation manquante');
+      if (!row.clientName) motifs.push('Client manquant');
+      if (row.nDi && existing.refs.has(row.nDi)) {
+        motifs.push(`N° DI « ${row.nDi} » déjà existant en base (non écrasé)`);
+      }
+      if (row.nDi && (seen.get(row.nDi) ?? 0) > 1) {
+        motifs.push(`N° DI « ${row.nDi} » en doublon dans le fichier`);
+      }
+
+      if (motifs.length > 0) {
+        erreurs.push({ ligne: row.ligne, valeurs: row.raw, motifs });
+        lignes.push({ ligne: row.ligne, statut: 'erreur', valeurs: row.raw, motifs });
+        continue;
+      }
+
+      // Valid row → may still carry non-blocking warnings.
+      valides++;
+      const rowWarnings: string[] = [];
+      if (!/^T\d+$/.test(row.nDi)) {
+        rowWarnings.push(`Format de réf « ${row.nDi} » inhabituel (attendu T{n})`);
+      }
+      const m = row.nDi.match(/^(?:DI|T)(\d+)$/);
+      if (m && parseInt(m[1], 10) >= existing.nextAuto) {
+        rowWarnings.push(
+          `N° DI « ${row.nDi} » ≥ prochaine réf auto-générée (T${existing.nextAuto}) — collision future possible`,
+        );
+      }
+      if (row.raw['Date de réception'] && !row.dateValue) {
+        rowWarnings.push(
+          `Date de réception « ${row.raw['Date de réception']} » non reconnue (ignorée)`,
+        );
+      }
+      for (const message of rowWarnings) {
+        warnings.push({ ligne: row.ligne, message });
+      }
+      lignes.push({
+        ligne: row.ligne,
+        statut: rowWarnings.length ? 'avertissement' : 'valide',
+        valeurs: row.raw,
+        motifs: rowWarnings,
+      });
+    }
+
+    return {
+      ligneEnTete: null,
+      total: rows.length,
+      valides,
+      warnings,
+      erreurs,
+      lignes,
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Persistence (dryRun=false)
+  // ---------------------------------------------------------------------------
+
+  private async persist(
+    rows: ParsedRow[],
+    report: ImportReport,
+    createdBy?: string,
+  ): Promise<ImportCrees> {
+    // Rows that errored during validation are excluded from the import set.
+    const errorLines = new Set(report.erreurs.map((e) => e.ligne));
+    const toImport = rows.filter((r) => !errorLines.has(r.ligne));
+
+    const clientCache = await this.buildClientCache();
+    const locationCache = await this.buildLocationCache();
+    let dis = 0;
+    let clientsCreated = 0;
+    let locationsCreated = 0;
+
+    for (const row of toImport) {
+      try {
+        const client = await this.resolveClient(row.clientName, clientCache);
+        if (client.created) clientsCreated++;
+
+        let locationId: string | undefined;
+        if (row.rangement) {
+          const loc = await this.resolveLocation(row.rangement, locationCache);
+          locationId = loc.id;
+          if (loc.created) locationsCreated++;
+        }
+
+        const input: any = {
+          title: row.designation,
+          nSerie: row.nSerie,
+          client_id: client.id,
+          location_id: locationId,
+          type_client: 'Client',
+          status: 'CREATED',
+          dateReception: row.dateValue ?? undefined,
+          createdBy,
+        };
+        await this.diService.createDi(input, {
+          forcedRef: row.nDi,
+          skipNotify: true,
+        });
+        dis++;
+      } catch (err) {
+        // A runtime failure on an otherwise-valid row: report it, keep going.
+        this.logger.error(
+          `Import row ${row.ligne} (${row.nDi}) failed: ${(err as Error)?.message ?? err}`,
+        );
+        report.erreurs.push({
+          ligne: row.ligne,
+          valeurs: row.raw,
+          motifs: [`Échec de création : ${(err as Error)?.message ?? err}`],
+        });
+        report.valides = Math.max(0, report.valides - 1);
+      }
+    }
+
+    return {
+      dis,
+      clients: clientsCreated,
+      locations: locationsCreated,
+      ignorees: rows.length - dis,
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Resolution helpers (idempotent within a single import)
+  // ---------------------------------------------------------------------------
+
+  private async loadExistingRefs(): Promise<{
+    refs: Set<string>;
+    nextAuto: number;
+  }> {
+    const docs = await this.diModel.find({}, { _idnum: 1 }).lean();
+    const refs = new Set<string>();
+    let max = 0;
+    for (const d of docs) {
+      const ref = this.str((d as any)?._idnum);
+      if (ref) refs.add(ref);
+      const m = ref.match(/^(?:DI|T)(\d+)$/);
+      if (m) {
+        const n = parseInt(m[1], 10);
+        if (Number.isFinite(n) && n > max) max = n;
+      }
+    }
+    return { refs, nextAuto: max + 1 };
+  }
+
+  private async buildClientCache(): Promise<Map<string, string>> {
+    const docs = await this.clientModel
+      .find({ isDeleted: { $ne: true } }, { _id: 1, first_name: 1, last_name: 1 })
+      .lean();
+    const map = new Map<string, string>();
+    for (const c of docs) {
+      const key = this.norm(`${(c as any).first_name ?? ''} ${(c as any).last_name ?? ''}`);
+      if (key && !map.has(key)) map.set(key, (c as any)._id);
+    }
+    return map;
+  }
+
+  private async resolveClient(
+    name: string,
+    cache: Map<string, string>,
+  ): Promise<{ id: string; created: boolean }> {
+    const key = this.norm(name);
+    const hit = cache.get(key);
+    if (hit) return { id: hit, created: false };
+    const created = await this.clientsService.createClient({
+      first_name: name.trim(),
+      last_name: '',
+    } as any);
+    cache.set(key, (created as any)._id);
+    return { id: (created as any)._id, created: true };
+  }
+
+  private async buildLocationCache(): Promise<Map<string, string>> {
+    const docs = await this.locationModel
+      .find({ isDeleted: { $ne: true } }, { _id: 1, location_name: 1 })
+      .lean();
+    const map = new Map<string, string>();
+    for (const l of docs) {
+      const key = this.norm((l as any).location_name);
+      if (key && !map.has(key)) map.set(key, (l as any)._id);
+    }
+    return map;
+  }
+
+  private async resolveLocation(
+    rangement: string,
+    cache: Map<string, string>,
+  ): Promise<{ id: string; created: boolean }> {
+    const key = this.norm(rangement);
+    const hit = cache.get(key);
+    if (hit) return { id: hit, created: false };
+    const created = await this.locationService.createlocation({
+      location_name: rangement.trim(),
+      avaible: true,
+    } as any);
+    cache.set(key, (created as any)._id);
+    return { id: (created as any)._id, created: true };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Primitives
+  // ---------------------------------------------------------------------------
+
+  /** Normalise a label / name: lower-case, strip accents, collapse to spaces. */
+  private norm(s: any): string {
+    return String(s ?? '')
+      .normalize('NFD')
+      .replace(/[̀-ͯ]/g, '')
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, ' ')
+      .trim()
+      .replace(/\s+/g, ' ');
+  }
+
+  /** Normalise a cell to a trimmed string (numbers → plain integer string). */
+  private str(v: any): string {
+    if (v == null) return '';
+    if (v instanceof Date) return isNaN(v.getTime()) ? '' : v.toISOString();
+    if (typeof v === 'number') {
+      // Avoid scientific notation for serials like 4821810100.
+      return Number.isInteger(v) ? String(v) : String(v).trim();
+    }
+    return String(v).trim();
+  }
+
+  /** Parse DD/MM/YYYY (or -/.) and Excel serials → UTC Date (no TZ offset). */
+  private parseDate(raw: any): Date | null {
+    if (raw == null || raw === '') return null;
+    if (raw instanceof Date) return isNaN(raw.getTime()) ? null : raw;
+    if (typeof raw === 'number') {
+      // Excel serial → JS Date (day 0 = 1899-12-30, accounts for the 1900 bug).
+      const ms = Date.UTC(1899, 11, 30) + Math.round(raw) * 86400000;
+      const d = new Date(ms);
+      return isNaN(d.getTime()) ? null : d;
+    }
+    const s = String(raw).trim();
+    const m = s.match(/^(\d{1,2})[\/\-.](\d{1,2})[\/\-.](\d{2,4})$/);
+    if (m) {
+      let year = parseInt(m[3], 10);
+      if (year < 100) year += 2000;
+      const day = parseInt(m[1], 10);
+      const month = parseInt(m[2], 10);
+      if (month < 1 || month > 12 || day < 1 || day > 31) return null;
+      const d = new Date(Date.UTC(year, month - 1, day));
+      return isNaN(d.getTime()) ? null : d;
+    }
+    const fallback = new Date(s);
+    return isNaN(fallback.getTime()) ? null : fallback;
+  }
+}


### PR DESCRIPTION
- Introduced `DiImportController` to handle REST endpoints for bulk DI import and template generation.
- Created `DiImportService` to manage the import logic, including validation and persistence of DIs.
- Added unit tests for `DiImportService` to ensure correct handling of various import scenarios.
- Updated `CreateDiInput` and `DiDocument` to include `dateReception` field for tracking reception dates.
- Implemented `RestJwtAuthGuard` for securing the import endpoint.
- Enhanced DI reference generation logic to avoid collisions with existing references.