### PR TITLE
feat: Implement company import/export functionality with XLSX support

### DIFF
--- a/qa/tests/dot-check.spec.ts
+++ b/qa/tests/dot-check.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect } from '@playwright/test';
+
+test.use({ storageState: '.auth/ADMIN_MANAGER.json' });
+
+test('point LOCATION : vide=vert, renseigné=rouge, meme valeur=meme couleur', async ({ page }) => {
+    await page.goto('http://localhost:4200/tickets/ticket/ticket-list');
+    await page.waitForSelector('.sav-location-dot', { timeout: 30000 });
+    await page.waitForTimeout(1500);
+
+    const rows = await page.$$eval('.sav-location-cell', (cells) =>
+        cells.map((c) => {
+            const dot = c.querySelector('.sav-location-dot') as HTMLElement;
+            const rgb = dot ? getComputedStyle(dot).backgroundColor : '';
+            return { texte: (c.textContent || '').trim(), rgb, classe: dot?.className || '' };
+        })
+    );
+
+    const NAME: Record<string, string> = { 'rgb(22, 163, 74)': 'VERT', 'rgb(220, 38, 38)': 'ROUGE' };
+    const VIDE = new Set(['', 'n/a', 'na', '—', '_', 'sans']);
+
+    console.log(`\n=== ${rows.length} cellules LOCATION rendues ===`);
+    const parValeur = new Map<string, Set<string>>();
+    for (const r of rows) {
+        const couleur = NAME[r.rgb] || r.rgb;
+        if (!parValeur.has(r.texte)) parValeur.set(r.texte, new Set());
+        parValeur.get(r.texte)!.add(couleur);
+    }
+    for (const [val, couleurs] of [...parValeur].sort()) {
+        const attendu = VIDE.has(val.toLowerCase()) ? 'VERT' : 'ROUGE';
+        const c = [...couleurs];
+        const ok = c.length === 1 && c[0] === attendu;
+        console.log(`${ok ? '  ok  ' : '  FAIL'}  ${JSON.stringify(val).padEnd(10)} -> ${c.join('+').padEnd(6)} (attendu ${attendu})`);
+        expect(c.length, `« ${val} » doit avoir UNE seule couleur, or: ${c.join(' + ')}`).toBe(1);
+        expect(c[0]).toBe(attendu);
+    }
+});

--- a/qa/utils/auth.ts
+++ b/qa/utils/auth.ts
@@ -59,7 +59,9 @@ export async function loginViaUI(page: Page, account: RoleAccount): Promise<Logi
     )
     .catch(() => null);
 
-  await page.getByRole('button', { name: 'Sign In' }).click();
+  // Le libellé du bouton a été francisé (« Se connecter ») lors de la refonte de
+  // la page de login ; on cible le submit du formulaire, insensible au libellé.
+  await page.locator('form button[type="submit"]').click();
 
   let httpStatus = 0;
   let errors: unknown[] | null = null;

--- a/src/company/company.module.ts
+++ b/src/company/company.module.ts
@@ -5,9 +5,12 @@ import { MongooseModule } from '@nestjs/mongoose';
 import { CompanySchema } from './entities/company.entity';
 import { GoogleDriveModule } from '../google-drive/google-drive.module';
 import { OperationalErrorModule } from '../operational-error/operational-error.module';
+import { CompanyImportController } from './import/company-import.controller';
+import { CompanyImportService } from './import/company-import.service';
 
 @Module({
-  providers: [CompanysResolver, CompanysService],
+  controllers: [CompanyImportController],
+  providers: [CompanysResolver, CompanysService, CompanyImportService],
   imports: [
     GoogleDriveModule,
     OperationalErrorModule,

--- a/src/company/company.service.spec.ts
+++ b/src/company/company.service.spec.ts
@@ -62,6 +62,24 @@ describe('CompanysService — téléphone de la société', () => {
       expect(out.raisonSociale).toBe('X SARL');
       expect(out.phone).toBeUndefined();
     });
+
+    it('durcissement : neutralise les chaînes « undefined »/« null » (jamais persistées)', async () => {
+      const out: any = await service.createcompany({
+        name: 'OK CO',
+        raisonSociale: 'OK CO',
+        Exoneration: 'undefined',
+        fax: 'null',
+        webSiteLink: 'UNDEFINED',
+        serviceAchat: { name: 'undefined', email: 'a@b.tn', phone: 'null' },
+      } as any);
+
+      expect(out.Exoneration).toBe('');
+      expect(out.fax).toBe('');
+      expect(out.webSiteLink).toBe('');
+      expect(out.serviceAchat.name).toBe(''); // récursif sur les contacts
+      expect(out.serviceAchat.email).toBe('a@b.tn'); // valeur réelle intacte
+      expect(out.serviceAchat.phone).toBe('');
+    });
   });
 
   describe('findAllCompanys — ordre par défaut « dernier créé en premier »', () => {

--- a/src/company/company.service.ts
+++ b/src/company/company.service.ts
@@ -23,6 +23,28 @@ function conflict(field: 'raisonSociale' | 'mf', message: string): GraphQLError 
 function escapeRegex(s: string): string {
   return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
+
+/**
+ * Neutralise les chaînes « undefined »/« null » (issues d'un ancien stringify
+ * de valeurs non définies) AVANT persistance : toute valeur string dont le trim
+ * insensible-casse vaut « undefined » ou « null » devient ''. Récursif (couvre
+ * les contacts par service). Empêche toute (ré)écriture de ce garbage.
+ */
+function stripUndefinedStrings<T>(obj: T): T {
+  if (obj == null || typeof obj !== 'object') return obj;
+  const out: any = Array.isArray(obj) ? [] : {};
+  for (const [k, v] of Object.entries(obj as any)) {
+    if (typeof v === 'string') {
+      const t = v.trim().toLowerCase();
+      out[k] = t === 'undefined' || t === 'null' ? '' : v;
+    } else if (v && typeof v === 'object') {
+      out[k] = stripUndefinedStrings(v);
+    } else {
+      out[k] = v;
+    }
+  }
+  return out;
+}
 import {
   CreateCompanyInput,
   PaginationConfig,
@@ -137,6 +159,8 @@ export class CompanysService {
   async createcompany(
     createCompanyInput: CreateCompanyInput,
   ): Promise<Company> {
+    // Durcissement : jamais de « undefined »/« null » persisté (voir helper).
+    createCompanyInput = stripUndefinedStrings(createCompanyInput);
     createCompanyInput._id = uuidv4(); //Societe
     await this.assertNoDuplicate(
       createCompanyInput.raisonSociale,
@@ -344,6 +368,8 @@ it should be soft delete ya nezih change it
   }
 
   async updateCompany(payload: UpdateCompanyInput) {
+    // Durcissement : neutralise « undefined »/« null » avant $set.
+    payload = stripUndefinedStrings(payload);
     // Renaming into another active company's raison sociale / MF is the same
     // business conflict as on create (the doc itself is excluded).
     await this.assertNoDuplicate(payload.raisonSociale, payload.mf, payload._id);
@@ -390,5 +416,41 @@ it should be soft delete ya nezih change it
       .select('_id name')
       .limit(20)
       .lean();
+  }
+
+  // ── Export / Import (xlsx) ────────────────────────────────────────────────
+
+  /** Toutes les sociétés actives (tous champs) pour l'export xlsx complet. */
+  async exportAllCompanies(): Promise<any[]> {
+    return this.CompanyModel.find({ isDeleted: { $ne: true } })
+      .sort({ createdAt: -1 })
+      .lean();
+  }
+
+  /** Index minimal { _id, mf, raisonSociale } des sociétés actives, pour
+   *  résoudre l'upsert d'import en mémoire (MF puis Raison sociale). */
+  async loadImportMatchIndex(): Promise<
+    Array<{ _id: string; mf?: string; raisonSociale?: string }>
+  > {
+    return this.CompanyModel.find({ isDeleted: { $ne: true } })
+      .select('_id mf raisonSociale')
+      .lean() as any;
+  }
+
+  /** Création via import (bulk) : PAS de dossier Drive (créé paresseusement plus
+   *  tard) pour ne pas ralentir/impacter l'API Drive sur un import de masse. */
+  async createFromImport(doc: Record<string, any>): Promise<string> {
+    const created = await new this.CompanyModel({
+      _id: uuidv4(),
+      ...doc,
+      isDeleted: false,
+    }).save();
+    return created._id as string;
+  }
+
+  /** Mise à jour via import : $set des champs fournis (fidélité round-trip —
+   *  une cellule vide écrase la valeur). Ne touche ni _id ni driveFolder*. */
+  async updateFromImport(id: string, doc: Record<string, any>): Promise<void> {
+    await this.CompanyModel.updateOne({ _id: id }, { $set: doc });
   }
 }

--- a/src/company/import/company-import.controller.ts
+++ b/src/company/import/company-import.controller.ts
@@ -1,0 +1,86 @@
+import {
+  BadRequestException,
+  Controller,
+  Get,
+  NotFoundException,
+  Param,
+  Post,
+  Query,
+  Res,
+  UploadedFile,
+  UseGuards,
+  UseInterceptors,
+} from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
+import { Response } from 'express';
+import { RestJwtAuthGuard } from 'src/auth/rest-jwt-auth-guard';
+import { CompanyImportService } from './company-import.service';
+
+/**
+ * Surface REST (hors GraphQL) pour l'export/import xlsx des sociétés :
+ *   GET  /company/export                 → toutes les sociétés (.xlsx)
+ *   GET  /company/export/:id             → une société (.xlsx)
+ *   GET  /company/import/template        → modèle vierge (.xlsx)
+ *   POST /company/import?dryRun=true|false  multipart `file` (.xlsx)
+ *        dryRun (défaut) = APERÇU sans écriture ; false = écriture réelle.
+ */
+const XLSX_MIME =
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
+
+@Controller('company')
+export class CompanyImportController {
+  constructor(private readonly importService: CompanyImportService) {}
+
+  @Get('export')
+  @UseGuards(RestJwtAuthGuard)
+  async exportAll(@Res() res: Response) {
+    const buffer = await this.importService.exportAll();
+    res.setHeader('Content-Type', XLSX_MIME);
+    res.setHeader('Content-Disposition', 'attachment; filename="societes.xlsx"');
+    res.send(buffer);
+  }
+
+  @Get('export/:id')
+  @UseGuards(RestJwtAuthGuard)
+  async exportOne(@Param('id') id: string, @Res() res: Response) {
+    const buffer = await this.importService.exportOne(id);
+    if (!buffer) throw new NotFoundException('Société introuvable.');
+    res.setHeader('Content-Type', XLSX_MIME);
+    res.setHeader(
+      'Content-Disposition',
+      `attachment; filename="societe_${id}.xlsx"`,
+    );
+    res.send(buffer);
+  }
+
+  @Get('import/template')
+  @UseGuards(RestJwtAuthGuard)
+  template(@Res() res: Response) {
+    const buffer = this.importService.buildTemplate();
+    res.setHeader('Content-Type', XLSX_MIME);
+    res.setHeader(
+      'Content-Disposition',
+      'attachment; filename="modele_import_societes.xlsx"',
+    );
+    res.send(buffer);
+  }
+
+  @Post('import')
+  @UseGuards(RestJwtAuthGuard)
+  @UseInterceptors(
+    FileInterceptor('file', { limits: { fileSize: 8 * 1024 * 1024, files: 1 } }),
+  )
+  async import(
+    @UploadedFile() file: { originalname?: string; buffer?: Buffer } | undefined,
+    @Query('dryRun') dryRun: string,
+  ) {
+    if (!file || !file.buffer) {
+      throw new BadRequestException('Fichier manquant (champ « file »).');
+    }
+    if (!/\.xlsx$/i.test(file.originalname ?? '')) {
+      throw new BadRequestException('Format invalide : un fichier .xlsx est attendu.');
+    }
+    const isDryRun = String(dryRun) !== 'false'; // défaut = aperçu SÛR
+    return this.importService.run(file.buffer, { dryRun: isDryRun });
+  }
+}

--- a/src/company/import/company-import.service.spec.ts
+++ b/src/company/import/company-import.service.spec.ts
@@ -1,0 +1,189 @@
+import * as XLSX from 'xlsx';
+import { CompanyImportService } from './company-import.service';
+import { EXPORT_HEADERS, companyToRow } from './company-io';
+
+/** Construit un buffer .xlsx à partir d'une matrice (en-têtes + lignes). */
+function xlsxBuffer(aoa: any[][]): Buffer {
+  const ws = XLSX.utils.aoa_to_sheet(aoa);
+  const wb = XLSX.utils.book_new();
+  XLSX.utils.book_append_sheet(wb, ws, 'S');
+  return XLSX.write(wb, { type: 'buffer', bookType: 'xlsx' });
+}
+
+/** Lit un buffer .xlsx → matrice de chaînes. */
+function readAoa(buf: Buffer): string[][] {
+  const wb = XLSX.read(buf, { type: 'buffer' });
+  const ws = wb.Sheets[wb.SheetNames[0]];
+  return XLSX.utils.sheet_to_json(ws, { header: 1, raw: false, defval: '' });
+}
+
+describe('CompanyImportService — export / import xlsx', () => {
+  function makeSvc(
+    index: Array<{ _id: string; mf?: string; raisonSociale?: string }> = [],
+    exportRows: any[] = [],
+  ) {
+    const companyService: any = {
+      loadImportMatchIndex: jest.fn().mockResolvedValue(index),
+      exportAllCompanies: jest.fn().mockResolvedValue(exportRows),
+      findOneCompany: jest.fn(),
+      createFromImport: jest.fn().mockResolvedValue('NEW_ID'),
+      updateFromImport: jest.fn().mockResolvedValue(undefined),
+    };
+    const svc = new CompanyImportService(companyService);
+    return { svc, companyService };
+  }
+
+  const FULL_COMPANY = {
+    _id: 'C1',
+    name: 'ACME',
+    raisonSociale: 'ACME SARL',
+    region: 'Tunis',
+    address: '12 rue',
+    email: 'contact@acme.tn',
+    phone: '+216 71 000 000',
+    fax: '+216 71 000 001',
+    webSiteLink: 'https://acme.tn',
+    mf: 'MF-1',
+    rne: 'B01',
+    Exoneration: 'Non',
+    activitePrincipale: 'Distribution',
+    activiteSecondaire: 'Maintenance',
+    serviceAchat: { name: 'Achat X', email: 'achat@acme.tn', phone: '+216 71 1' },
+    serviceTechnique: { name: 'Tech Y', email: 'tech@acme.tn', phone: '+216 71 2' },
+    serviceFinancier: { name: 'Fin Z', email: 'fin@acme.tn', phone: '+216 71 3' },
+  };
+
+  // ── EXPORT ──────────────────────────────────────────────────────────────
+
+  it('export : bons en-têtes (schéma canonique) + données correctes', async () => {
+    const { svc } = makeSvc([], [FULL_COMPANY]);
+    const buf = await svc.exportAll();
+    const aoa = readAoa(buf);
+
+    expect(aoa[0]).toEqual(EXPORT_HEADERS); // 22 colonnes, ordre exact
+    expect(aoa[1]).toEqual(companyToRow(FULL_COMPANY));
+    // Contacts embedded bien à plat dans les colonnes dédiées.
+    const iAchatNom = EXPORT_HEADERS.indexOf('Contact Achat Nom');
+    expect(aoa[1][iAchatNom]).toBe('Achat X');
+  });
+
+  it('export : la chaîne legacy "undefined" est nettoyée en cellule vide', async () => {
+    const { svc } = makeSvc([], [{ raisonSociale: 'undefined', name: 'X' }]);
+    const aoa = readAoa(await svc.exportAll());
+    const iRs = EXPORT_HEADERS.indexOf('Raison sociale');
+    expect(aoa[1][iRs]).toBe('');
+  });
+
+  // ── IMPORT ──────────────────────────────────────────────────────────────
+
+  it('import valide → CRÉE (aucune correspondance existante)', async () => {
+    const { svc, companyService } = makeSvc([]);
+    const buf = xlsxBuffer([
+      EXPORT_HEADERS,
+      ['NOUV', 'NOUVELLE CO', 'Tunis', 'adr', 'a@b.tn', '+216 71 0', '', '', 'MF-9', '', 'Oui', '', '', 'AN', 'an@b.tn', '', '', '', '', '', '', ''],
+    ]);
+    const rep = await svc.run(buf, { dryRun: false });
+
+    expect(rep.enTeteInvalide).toBeFalsy();
+    expect(rep.aCreer).toBe(1);
+    expect(rep.aMettreAJour).toBe(0);
+    expect(companyService.createFromImport).toHaveBeenCalledTimes(1);
+    const doc = companyService.createFromImport.mock.calls[0][0];
+    expect(doc.raisonSociale).toBe('NOUVELLE CO');
+    expect(doc.name).toBe('NOUV'); // Nom et Raison sociale distincts (2 colonnes)
+    expect(doc.serviceAchat).toEqual({ name: 'AN', email: 'an@b.tn', phone: '' });
+    expect(rep.crees).toEqual({ crees: 1, majs: 0, erreurs: 0 });
+  });
+
+  it('import → MET À JOUR par Matricule fiscale (upsert)', async () => {
+    const { svc, companyService } = makeSvc([
+      { _id: 'C1', mf: 'MF-1', raisonSociale: 'ANCIEN NOM' },
+    ]);
+    const row = companyToRow(FULL_COMPANY); // mf MF-1 → doit matcher C1
+    const rep = await svc.run(xlsxBuffer([EXPORT_HEADERS, row]), { dryRun: false });
+
+    expect(rep.aMettreAJour).toBe(1);
+    expect(rep.aCreer).toBe(0);
+    expect(companyService.updateFromImport).toHaveBeenCalledWith('C1', expect.any(Object));
+    expect(companyService.createFromImport).not.toHaveBeenCalled();
+  });
+
+  it('import → MET À JOUR par Raison sociale (insensible casse) si pas de MF', async () => {
+    const { svc, companyService } = makeSvc([
+      { _id: 'C7', mf: '', raisonSociale: 'Beta SARL' },
+    ]);
+    const buf = xlsxBuffer([
+      EXPORT_HEADERS,
+      ['', 'BETA SARL', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', ''],
+    ]);
+    const rep = await svc.run(buf, { dryRun: false });
+    expect(rep.aMettreAJour).toBe(1);
+    expect(companyService.updateFromImport).toHaveBeenCalledWith('C7', expect.any(Object));
+  });
+
+  it('lignes invalides : les bonnes passent, les mauvaises rejetées AVEC raison', async () => {
+    const { svc, companyService } = makeSvc([]);
+    const buf = xlsxBuffer([
+      EXPORT_HEADERS,
+      ['A', 'VALIDE CO', '', '', '', '', '', '', 'MF-A', '', '', '', '', '', '', '', '', '', '', '', '', ''],
+      ['B', '', '', '', '', '', '', '', 'MF-B', '', '', '', '', '', '', '', '', '', '', '', '', ''], // raison sociale manquante
+    ]);
+    const rep = await svc.run(buf, { dryRun: false });
+
+    expect(rep.total).toBe(2);
+    expect(rep.valides).toBe(1);
+    expect(rep.erreurs).toHaveLength(1);
+    expect(rep.erreurs[0].motifs.join(' ')).toMatch(/Raison sociale manquante/i);
+    expect(companyService.createFromImport).toHaveBeenCalledTimes(1); // seule la bonne écrite
+  });
+
+  it('dryRun = APERÇU : aucune écriture', async () => {
+    const { svc, companyService } = makeSvc([]);
+    const buf = xlsxBuffer([
+      EXPORT_HEADERS,
+      ['X', 'PREVIEW CO', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', '', ''],
+    ]);
+    const rep = await svc.run(buf, { dryRun: true });
+    expect(rep.aCreer).toBe(1);
+    expect(companyService.createFromImport).not.toHaveBeenCalled();
+    expect(companyService.updateFromImport).not.toHaveBeenCalled();
+    expect(rep.crees).toBeUndefined();
+  });
+
+  it('ROUND-TRIP idempotent : réimporter l\'export ne duplique pas (upsert)', async () => {
+    // 1) export
+    const { svc: exporter } = makeSvc([], [FULL_COMPANY]);
+    const exported = await exporter.exportAll();
+    // 2) réimport, la société existe déjà (même mf)
+    const { svc, companyService } = makeSvc([
+      { _id: 'C1', mf: 'MF-1', raisonSociale: 'ACME SARL' },
+    ]);
+    const rep = await svc.run(exported, { dryRun: false });
+
+    expect(rep.aCreer).toBe(0); // rien de créé
+    expect(rep.aMettreAJour).toBe(1); // simple mise à jour
+    expect(companyService.createFromImport).not.toHaveBeenCalled();
+    expect(companyService.updateFromImport).toHaveBeenCalledTimes(1);
+  });
+
+  it('en-tête invalide : « Raison sociale » absente → rejet propre (aucune écriture)', async () => {
+    const { svc, companyService } = makeSvc([]);
+    const buf = xlsxBuffer([['Nom', 'Ville'], ['ACME', 'Tunis']]);
+    const rep = await svc.run(buf, { dryRun: false });
+    expect(rep.enTeteInvalide).toBe(true);
+    expect(rep.erreurs[0].motifs[0]).toMatch(/Raison sociale/i);
+    expect(companyService.createFromImport).not.toHaveBeenCalled();
+  });
+
+  it('doublon intra-fichier (même MF) → 2e ligne en erreur', async () => {
+    const { svc } = makeSvc([]);
+    const buf = xlsxBuffer([
+      EXPORT_HEADERS,
+      ['', 'CO 1', '', '', '', '', '', '', 'MF-DUP', '', '', '', '', '', '', '', '', '', '', '', '', ''],
+      ['', 'CO 2', '', '', '', '', '', '', 'MF-DUP', '', '', '', '', '', '', '', '', '', '', '', '', ''],
+    ]);
+    const rep = await svc.run(buf, { dryRun: true });
+    expect(rep.valides).toBe(1);
+    expect(rep.erreurs.some((e) => /Doublon dans le fichier/i.test(e.motifs.join(' ')))).toBe(true);
+  });
+});

--- a/src/company/import/company-import.service.ts
+++ b/src/company/import/company-import.service.ts
@@ -1,0 +1,359 @@
+import { Injectable, Logger } from '@nestjs/common';
+import * as XLSX from 'xlsx';
+import { CompanysService } from '../company.service';
+import {
+  COMPANY_COLUMNS,
+  CompanyColumn,
+  EXPORT_HEADERS,
+  EMAIL_RE,
+  PHONE_RE,
+  companyToRow,
+  cleanCell,
+  normHeader,
+} from './company-io';
+
+/**
+ * Export / import xlsx des sociétés — MÊME schéma canonique dans les deux sens
+ * (voir company-io). Import en 2 temps : `dryRun` = APERÇU (aucune écriture) →
+ * l'utilisateur confirme → écriture réelle. Rapport PAR LIGNE (jamais d'échec
+ * global sur une mauvaise ligne). Upsert : MF si présent+trouvé, sinon Raison
+ * sociale (insensible casse), sinon création.
+ */
+
+export interface ImportWarning {
+  ligne: number;
+  message: string;
+}
+export interface ImportError {
+  ligne: number;
+  valeurs: Record<string, string>;
+  motifs: string[];
+}
+export type LigneStatut = 'valide' | 'avertissement' | 'erreur';
+export type LigneAction = 'create' | 'update' | null;
+export interface ImportLigne {
+  ligne: number;
+  statut: LigneStatut;
+  action: LigneAction;
+  valeurs: Record<string, string>;
+  motifs: string[];
+}
+export interface ImportReport {
+  ligneEnTete: number | null;
+  total: number;
+  valides: number;
+  aCreer: number;
+  aMettreAJour: number;
+  warnings: ImportWarning[];
+  erreurs: ImportError[];
+  lignes: ImportLigne[];
+  enTeteInvalide?: boolean;
+  crees?: { crees: number; majs: number; erreurs: number };
+}
+
+interface PreparedRow {
+  ligne: number;
+  doc: Record<string, any>; // document société à écrire
+  raisonSociale: string;
+  mf: string;
+  action: LigneAction;
+  matchId: string | null;
+  raw: Record<string, string>;
+}
+
+function setPath(obj: any, path: string[], value: any): void {
+  let o = obj;
+  for (let i = 0; i < path.length - 1; i++) {
+    o[path[i]] = o[path[i]] ?? {};
+    o = o[path[i]];
+  }
+  o[path[path.length - 1]] = value;
+}
+
+@Injectable()
+export class CompanyImportService {
+  private readonly logger = new Logger(CompanyImportService.name);
+
+  constructor(private readonly companyService: CompanysService) {}
+
+  // ── EXPORT ──────────────────────────────────────────────────────────────
+
+  private buildWorkbook(companies: any[], sheet = 'Sociétés'): Buffer {
+    const aoa = [EXPORT_HEADERS, ...companies.map((c) => companyToRow(c))];
+    const ws = XLSX.utils.aoa_to_sheet(aoa);
+    ws['!cols'] = EXPORT_HEADERS.map((h) => ({ wch: Math.max(12, h.length + 2) }));
+    const wb = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(wb, ws, sheet);
+    return XLSX.write(wb, { type: 'buffer', bookType: 'xlsx' });
+  }
+
+  /** Toutes les sociétés (tous champs) → .xlsx. Sert aussi de modèle d'import. */
+  async exportAll(): Promise<Buffer> {
+    const companies = await this.companyService.exportAllCompanies();
+    return this.buildWorkbook(companies);
+  }
+
+  /** Une seule société → .xlsx (même schéma). */
+  async exportOne(id: string): Promise<Buffer | null> {
+    const company = await this.companyService.findOneCompany(id).catch(() => null);
+    if (!company) return null;
+    return this.buildWorkbook([company]);
+  }
+
+  /** Modèle vierge (en-têtes + une ligne d'exemple). */
+  buildTemplate(): Buffer {
+    const example: any = {
+      name: 'ACME',
+      raisonSociale: 'ACME SARL',
+      region: 'Tunis',
+      address: '12 rue de Carthage',
+      email: 'contact@acme.tn',
+      phone: '+216 71 000 000',
+      fax: '+216 71 000 001',
+      webSiteLink: 'https://acme.tn',
+      mf: '1234567/A/M/000',
+      rne: 'B0123456',
+      Exoneration: 'Non',
+      activitePrincipale: 'Distribution',
+      activiteSecondaire: 'Maintenance',
+      serviceAchat: { name: 'A. Achat', email: 'achat@acme.tn', phone: '+216 71 000 010' },
+      serviceTechnique: { name: 'T. Tech', email: 'tech@acme.tn', phone: '+216 71 000 020' },
+      serviceFinancier: { name: 'F. Fin', email: 'fin@acme.tn', phone: '+216 71 000 030' },
+    };
+    return this.buildWorkbook([example], 'Modèle');
+  }
+
+  // ── IMPORT ──────────────────────────────────────────────────────────────
+
+  async run(buffer: Buffer, opts: { dryRun: boolean }): Promise<ImportReport> {
+    const parsed = this.parse(buffer);
+    if (parsed.enTeteInvalide) return parsed.report;
+
+    const index = await this.companyService.loadImportMatchIndex();
+    const byMf = new Map<string, string>();
+    const byRs = new Map<string, string>();
+    for (const c of index) {
+      if (c.mf && c.mf.trim()) byMf.set(c.mf.trim(), c._id);
+      if (c.raisonSociale && c.raisonSociale.trim())
+        byRs.set(c.raisonSociale.trim().toLowerCase(), c._id);
+    }
+
+    const report = this.validate(parsed.rows, byMf, byRs);
+    report.ligneEnTete = parsed.headerLine;
+    if (opts.dryRun) return report;
+
+    await this.persist(parsed.rows, report);
+    return report;
+  }
+
+  // ── Parsing (en-tête par label ; n° de ligne Excel réels 1-based) ──
+
+  private parse(buffer: Buffer): {
+    rows: PreparedRow[];
+    headerLine: number | null;
+    enTeteInvalide: boolean;
+    report: ImportReport;
+  } {
+    const fail = (msg: string): any => ({
+      rows: [],
+      headerLine: null,
+      enTeteInvalide: true,
+      report: {
+        ligneEnTete: null,
+        total: 0,
+        valides: 0,
+        aCreer: 0,
+        aMettreAJour: 0,
+        warnings: [],
+        erreurs: [{ ligne: 0, valeurs: {}, motifs: [msg] }],
+        lignes: [],
+        enTeteInvalide: true,
+      },
+    });
+
+    let wb: XLSX.WorkBook;
+    try {
+      wb = XLSX.read(buffer, { type: 'buffer', cellDates: true });
+    } catch {
+      return fail('Fichier illisible : .xlsx valide attendu.');
+    }
+    const sheet = wb.SheetNames[0] ? wb.Sheets[wb.SheetNames[0]] : undefined;
+    if (!sheet || !sheet['!ref']) return fail('Feuille vide : aucune donnée détectée.');
+
+    const range = XLSX.utils.decode_range(sheet['!ref']);
+    const cell = (r: number, c: number): any => {
+      const cl = (sheet as any)[XLSX.utils.encode_cell({ r, c })];
+      return cl ? cl.v : null;
+    };
+
+    // En-tête = 1re ligne contenant AU MOINS « Raison sociale ».
+    const wantedByHeader = new Map<string, CompanyColumn>();
+    for (const col of COMPANY_COLUMNS) wantedByHeader.set(normHeader(col.header), col);
+
+    let headerRow = -1;
+    const colIndex = new Map<CompanyColumn, number>();
+    for (let r = range.s.r; r <= range.e.r; r++) {
+      const found = new Map<CompanyColumn, number>();
+      for (let c = range.s.c; c <= range.e.c; c++) {
+        const col = wantedByHeader.get(normHeader(cell(r, c)));
+        if (col && !found.has(col)) found.set(col, c);
+      }
+      const rsCol = COMPANY_COLUMNS.find((x) => x.path[0] === 'raisonSociale')!;
+      if (found.has(rsCol)) {
+        headerRow = r;
+        found.forEach((v, k) => colIndex.set(k, v));
+        break;
+      }
+    }
+    if (headerRow === -1) {
+      return fail('En-tête introuvable : la colonne « Raison sociale » est requise.');
+    }
+
+    const rows: PreparedRow[] = [];
+    for (let r = headerRow + 1; r <= range.e.r; r++) {
+      const doc: Record<string, any> = {};
+      const raw: Record<string, string> = {};
+      let anyValue = false;
+
+      for (const col of COMPANY_COLUMNS) {
+        const c = colIndex.get(col);
+        let val = c != null ? cleanCell(cell(r, c)) : '';
+        if (col.kind === 'exon') val = this.normExon(val);
+        raw[col.header] = val;
+        if (val) anyValue = true;
+        setPath(doc, col.path, val);
+      }
+      if (!anyValue) continue; // ligne vide
+
+      rows.push({
+        ligne: r + 1,
+        doc,
+        raisonSociale: (doc.raisonSociale ?? '').toString(),
+        mf: (doc.mf ?? '').toString(),
+        action: null,
+        matchId: null,
+        raw,
+      });
+    }
+
+    return { rows, headerLine: headerRow + 1, enTeteInvalide: false, report: null as any };
+  }
+
+  // ── Validation + résolution upsert (sans écrire) ──
+
+  private validate(
+    rows: PreparedRow[],
+    byMf: Map<string, string>,
+    byRs: Map<string, string>,
+  ): ImportReport {
+    const warnings: ImportWarning[] = [];
+    const erreurs: ImportError[] = [];
+    const lignes: ImportLigne[] = [];
+    let valides = 0;
+    let aCreer = 0;
+    let aMettreAJour = 0;
+    const seenKeys = new Set<string>(); // doublons INTRA-fichier
+
+    for (const row of rows) {
+      const motifs: string[] = [];
+      const rowWarnings: string[] = [];
+
+      if (!row.raisonSociale.trim()) motifs.push('Raison sociale manquante (obligatoire)');
+
+      // Formats (non bloquants → avertissements).
+      for (const col of COMPANY_COLUMNS) {
+        const v = row.raw[col.header];
+        if (!v) continue;
+        if (col.kind === 'email' && !EMAIL_RE.test(v))
+          rowWarnings.push(`${col.header} : e-mail au format douteux`);
+        if (col.kind === 'phone' && !PHONE_RE.test(v))
+          rowWarnings.push(`${col.header} : téléphone au format douteux`);
+        if (col.kind === 'exon' && v !== 'Oui' && v !== 'Non')
+          rowWarnings.push(`Exonération : « Oui »/« Non » attendu`);
+      }
+
+      // Doublon intra-fichier sur la clé d'upsert.
+      const key = row.mf.trim()
+        ? 'mf:' + row.mf.trim()
+        : 'rs:' + row.raisonSociale.trim().toLowerCase();
+      if (row.raisonSociale.trim() && seenKeys.has(key)) {
+        motifs.push('Doublon dans le fichier (même MF ou Raison sociale)');
+      }
+
+      if (motifs.length) {
+        erreurs.push({ ligne: row.ligne, valeurs: row.raw, motifs });
+        lignes.push({ ligne: row.ligne, statut: 'erreur', action: null, valeurs: row.raw, motifs });
+        continue;
+      }
+      seenKeys.add(key);
+
+      // Résolution upsert : MF d'abord, puis Raison sociale (ci).
+      let matchId: string | null = null;
+      if (row.mf.trim() && byMf.has(row.mf.trim())) matchId = byMf.get(row.mf.trim())!;
+      else if (byRs.has(row.raisonSociale.trim().toLowerCase()))
+        matchId = byRs.get(row.raisonSociale.trim().toLowerCase())!;
+
+      row.action = matchId ? 'update' : 'create';
+      row.matchId = matchId;
+      if (matchId) aMettreAJour++;
+      else aCreer++;
+      valides++;
+
+      for (const w of rowWarnings) warnings.push({ ligne: row.ligne, message: w });
+      lignes.push({
+        ligne: row.ligne,
+        statut: rowWarnings.length ? 'avertissement' : 'valide',
+        action: row.action,
+        valeurs: row.raw,
+        motifs: rowWarnings,
+      });
+    }
+
+    return {
+      ligneEnTete: null,
+      total: rows.length,
+      valides,
+      aCreer,
+      aMettreAJour,
+      warnings,
+      erreurs,
+      lignes,
+    };
+  }
+
+  // ── Écriture (upsert), par ligne, tolérante aux échecs ──
+
+  private async persist(rows: PreparedRow[], report: ImportReport): Promise<void> {
+    let crees = 0;
+    let majs = 0;
+    let echecs = 0;
+
+    for (const row of rows) {
+      if (row.action == null) continue; // ligne en erreur
+      try {
+        if (row.action === 'update' && row.matchId) {
+          await this.companyService.updateFromImport(row.matchId, row.doc);
+          majs++;
+        } else {
+          await this.companyService.createFromImport(row.doc);
+          crees++;
+        }
+      } catch (err) {
+        echecs++;
+        report.valides = Math.max(0, report.valides - 1);
+        const motif = `Échec d'écriture : ${(err as Error)?.message ?? err}`;
+        report.erreurs.push({ ligne: row.ligne, valeurs: row.raw, motifs: [motif] });
+        this.logger.error(`Import société ligne ${row.ligne} échouée : ${motif}`);
+      }
+    }
+
+    report.crees = { crees, majs, erreurs: echecs };
+  }
+
+  private normExon(v: string): string {
+    const t = v.trim().toLowerCase();
+    if (t === 'oui') return 'Oui';
+    if (t === 'non') return 'Non';
+    return v.trim() === '' ? '' : v.trim(); // valeur douteuse gardée → avertissement en validation
+  }
+}

--- a/src/company/import/company-io.ts
+++ b/src/company/import/company-io.ts
@@ -1,0 +1,80 @@
+/**
+ * SCHÉMA CANONIQUE des colonnes société — SOURCE DE VÉRITÉ UNIQUE partagée par
+ * l'export ET l'import. L'ordre du tableau = l'ordre des colonnes du .xlsx, et
+ * les mêmes en-têtes servent de modèle d'import (round-trip : exporter → éditer
+ * dans Excel → réimporter le MÊME fichier sans duplication).
+ *
+ * Chaque colonne mappe un en-tête ↔ un chemin dans le document Company. Les
+ * contacts par service sont EMBEDDED ({name,email,phone}) et la région est un
+ * simple texte → aucune résolution nom→id : on lit/écrit la valeur telle quelle.
+ */
+export type CompanyColKind = 'text' | 'email' | 'phone' | 'exon';
+
+export interface CompanyColumn {
+  header: string; // en-tête EXACT du .xlsx (export l'écrit, import le matche)
+  path: string[]; // chemin dans le doc, ex. ['raisonSociale'] | ['serviceAchat','name']
+  kind?: CompanyColKind;
+  required?: boolean;
+}
+
+export const COMPANY_COLUMNS: CompanyColumn[] = [
+  { header: 'Nom', path: ['name'] },
+  { header: 'Raison sociale', path: ['raisonSociale'], required: true },
+  { header: 'Région', path: ['region'] },
+  { header: 'Adresse', path: ['address'] },
+  { header: 'E-mail', path: ['email'], kind: 'email' },
+  { header: 'Téléphone', path: ['phone'], kind: 'phone' },
+  { header: 'Fax', path: ['fax'], kind: 'phone' },
+  { header: 'Website', path: ['webSiteLink'] },
+  { header: 'Matricule fiscale', path: ['mf'] },
+  { header: 'RNE', path: ['rne'] },
+  { header: 'Exonération', path: ['Exoneration'], kind: 'exon' },
+  { header: 'Activité principale', path: ['activitePrincipale'] },
+  { header: 'Activité secondaire', path: ['activiteSecondaire'] },
+  { header: 'Contact Achat Nom', path: ['serviceAchat', 'name'] },
+  { header: 'Contact Achat E-mail', path: ['serviceAchat', 'email'], kind: 'email' },
+  { header: 'Contact Achat Téléphone', path: ['serviceAchat', 'phone'], kind: 'phone' },
+  { header: 'Contact Technique Nom', path: ['serviceTechnique', 'name'] },
+  { header: 'Contact Technique E-mail', path: ['serviceTechnique', 'email'], kind: 'email' },
+  { header: 'Contact Technique Téléphone', path: ['serviceTechnique', 'phone'], kind: 'phone' },
+  { header: 'Contact Financier Nom', path: ['serviceFinancier', 'name'] },
+  { header: 'Contact Financier E-mail', path: ['serviceFinancier', 'email'], kind: 'email' },
+  { header: 'Contact Financier Téléphone', path: ['serviceFinancier', 'phone'], kind: 'phone' },
+];
+
+/** En-têtes exacts, dans l'ordre — l'export et le modèle d'import les utilisent. */
+export const EXPORT_HEADERS: string[] = COMPANY_COLUMNS.map((c) => c.header);
+
+// ── Primitives partagées ────────────────────────────────────────────────────
+
+/** Normalise un en-tête pour un match tolérant (accents, casse, ponctuation). */
+export function normHeader(s: unknown): string {
+  return String(s ?? '')
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim()
+    .replace(/\s+/g, ' ');
+}
+
+/** Valeur d'affichage propre : null/undefined et les chaînes legacy
+ *  "undefined"/"null" deviennent '' (jamais écrites dans l'export). */
+export function cleanCell(v: unknown): string {
+  if (v == null) return '';
+  const s = v instanceof Date ? (isNaN(v.getTime()) ? '' : v.toISOString()) : String(v);
+  const t = s.trim().toLowerCase();
+  return t === '' || t === 'undefined' || t === 'null' ? '' : s.trim();
+}
+
+function getPath(obj: any, path: string[]): any {
+  return path.reduce((o, k) => (o == null ? o : o[k]), obj);
+}
+
+/** Company (doc) → ligne de cellules, dans l'ordre canonique. */
+export function companyToRow(company: any): string[] {
+  return COMPANY_COLUMNS.map((c) => cleanCell(getPath(company, c.path)));
+}
+
+export const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/;
+export const PHONE_RE = /^[+0-9 ()\-.]{6,20}$/;

--- a/src/stat/stat.get-stat-by-id-logs.spec.ts
+++ b/src/stat/stat.get-stat-by-id-logs.spec.ts
@@ -1,0 +1,54 @@
+import { StatService } from './stat.service';
+
+/**
+ * getStatByIdlogs — régression : une DI SANS pause logs (jamais mise en pause,
+ * p.ex. pas un retour) ne doit PLUS lever « No logs found ». C'était la cause de
+ * l'alerte opérationnelle INTERNAL_SERVER_ERROR sur les listes ticket/coordinateur.
+ *
+ * Test isolé sur le prototype (le TestModule complet du service échoue déjà sur
+ * la résolution DI — non lié).
+ */
+describe('StatService.getStatByIdlogs — pas de crash sans logs', () => {
+  function makeSvc(stat: any) {
+    const svc: any = Object.create(StatService.prototype);
+    svc.StatModel = { findOne: jest.fn().mockResolvedValue(stat) };
+    svc.profileService = { getTech: jest.fn().mockResolvedValue('Tech Name') };
+    svc.operationalErrorService = { capture: jest.fn().mockResolvedValue(undefined) };
+    return svc;
+  }
+
+  it('retourne le stat (sans throw) quand pauseLogs est VIDE', async () => {
+    const svc = makeSvc({ _idDi: 'DI1', pauseLogs: [] });
+    const res = await svc.getStatByIdlogs('DI1');
+    expect(res).toMatchObject({ _idDi: 'DI1', pauseLogs: [] });
+    // Aucune alerte opérationnelle levée pour un état normal.
+    expect(svc.operationalErrorService.capture).not.toHaveBeenCalled();
+  });
+
+  it('ne plante pas si pauseLogs est undefined', async () => {
+    const svc = makeSvc({ _idDi: 'DI2' }); // pas de champ pauseLogs
+    await expect(svc.getStatByIdlogs('DI2')).resolves.toMatchObject({
+      _idDi: 'DI2',
+    });
+    expect(svc.operationalErrorService.capture).not.toHaveBeenCalled();
+  });
+
+  it('résout toujours les techs quand des logs existent (non-régression)', async () => {
+    const svc = makeSvc({
+      _idDi: 'DI3',
+      pauseLogs: [{ at: new Date() }],
+      id_tech_diag: 'T_DIAG',
+      id_tech_rep: 'T_REP',
+    });
+    const res = await svc.getStatByIdlogs('DI3');
+    expect(svc.profileService.getTech).toHaveBeenCalledWith('T_DIAG');
+    expect(svc.profileService.getTech).toHaveBeenCalledWith('T_REP');
+    expect(res.id_tech_diag).toBe('Tech Name');
+  });
+
+  it('lève toujours quand AUCUN stat n’existe (comportement inchangé)', async () => {
+    const svc = makeSvc(null);
+    await expect(svc.getStatByIdlogs('DI4')).rejects.toThrow('Stat not found');
+    expect(svc.operationalErrorService.capture).toHaveBeenCalled();
+  });
+});

--- a/src/stat/stat.service.ts
+++ b/src/stat/stat.service.ts
@@ -1012,9 +1012,11 @@ export class StatService {
       if (!stat) {
         throw new Error('Stat not found');
       }
-      if (stat.pauseLogs.length === 0) {
-        throw new Error('No logs found');
-      }
+      // Une DI jamais mise en pause a `pauseLogs` vide : c'est un état NORMAL
+      // (ex. DI qui n'est pas un retour), PAS une erreur. On ne lève plus rien
+      // ici — sinon l'affichage des listes ticket/coordinateur déclenchait une
+      // alerte opérationnelle « No logs found » (INTERNAL_SERVER_ERROR) pour
+      // chaque DI sans logs. Le front gère déjà l'absence de logs (`|| []`).
       if (stat.id_tech_diag) {
         const techdiag = await this.profileService.getTech(stat.id_tech_diag);
         stat.id_tech_diag = techdiag;


### PR DESCRIPTION
- Added CompanyImportController and CompanyImportService for handling XLSX file import and export.
- Introduced company-io.ts for defining the canonical schema of company columns and utility functions for data cleaning and transformation.
- Enhanced CompanysService to include methods for exporting all companies and creating/updating from import.
- Added tests for the import/export functionality to ensure data integrity and proper handling of edge cases.
- Updated existing services and tests to accommodate changes in the company data handling process.
- Modified login functionality to target the submit button directly, improving robustness against UI changes.
- Added regression tests for StatService to ensure no errors are thrown when logs are absent.